### PR TITLE
Fix console script entry point to use sync wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project.scripts]
-shell-mcp-server = "shell_mcp_server.server:main"
+shell-mcp-server = "shell_mcp_server:main"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Fixes #3

**Problem**: Console script was pointing to `shell_mcp_server.server:main` (async function) causing RuntimeWarning: coroutine 'main' was never awaited.

**Solution**: Changed entry point to `shell_mcp_server:main` (sync wrapper with asyncio.run).

**Changes**:
- Updated `pyproject.toml` line 15 to use the correct entry point
- Removed `.server` from the console script configuration

**Testing**: 
- ✅ Server now starts without coroutine warnings
- ✅ Entry point calls sync wrapper which properly handles async code
- ✅ No breaking changes to functionality

**Root Cause**: The console script was directly calling an async function instead of the sync wrapper that exists in `__init__.py`.

This one-line fix resolves the packaging configuration issue reported in issue #3.